### PR TITLE
Support for github RequestSource in GitlabCI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 -->
 
 ## master
+* Support external CI/CD for GitlabCI with Github code repository. To utilize this, please ensure `DANGER_GITHUB_API_TOKEN` and `DANGER_PROJECT_REPO_URL` are both set. [@philipqnguyen](https://github.com/philipqnguyen) [#1238](https://github.com/danger/danger/pull/1238)
 
 ## 8.0.2
 

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -40,6 +40,10 @@ module Danger
         end
       end
 
+      def validates_as_ci?
+        true
+      end
+
       def validates_as_api_source?
         (@token && !@token.empty?) || self.environment["DANGER_USE_LOCAL_GIT"]
       end

--- a/spec/lib/danger/ci_sources/gitlab_ci_spec.rb
+++ b/spec/lib/danger/ci_sources/gitlab_ci_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe Danger::GitLabCI, host: :gitlab do
       it "it is gitlab" do
         expect(
           ci_source.supported_request_sources
-        ).to eq([Danger::RequestSources::GitLab])
+        ).to eq([Danger::RequestSources::GitHub,
+                 Danger::RequestSources::GitLab])
       end
     end
 
@@ -92,6 +93,58 @@ RSpec.describe Danger::GitLabCI, host: :gitlab do
       describe "#pull_request_id" do
         it "sets the pull_request_id" do
           expect(ci_source.pull_request_id).to eq(env["CI_MERGE_REQUEST_IID"])
+        end
+      end
+    end
+
+    context "given PR made on github hosted repository" do
+      let(:pr_num) { '24' }
+      let(:repo_url) { 'https://github.com/procore/blueprinter' }
+      let(:repo_slug) { 'procore/blueprinter' }
+      let(:env) do
+        stub_env.merge(
+          {
+            "CI_EXTERNAL_PULL_REQUEST_IID" => pr_num,
+            "DANGER_PROJECT_REPO_URL" => repo_url
+          }
+        )
+      end
+
+      describe ".validates_as_ci?" do
+        it "is valid" do
+          expect(described_class.validates_as_ci?(env)).to be(true)
+        end
+      end
+
+      describe ".validates_as_pr?" do
+        it "is valid" do
+          expect(described_class.validates_as_pr?(env)).to be(true)
+        end
+      end
+
+      describe ".determine_pull_or_merge_request_id" do
+        context "when CI_MERGE_REQUEST_IID present in environment" do
+          it "returns CI_MERGE_REQUEST_IID" do
+            expect(described_class.determine_pull_or_merge_request_id(env)).to eq(pr_num)
+          end
+        end
+      end
+
+      describe "#initialize" do
+        it "sets the repo_slug" do
+          expect(ci_source.repo_slug).to eq(repo_slug)
+        end
+      end
+
+      describe "#project_url" do
+        it "sets the project_url" do
+          expect(ci_source.project_url).to eq(repo_url)
+        end
+      end
+
+      describe "#pull_request_id" do
+        it "sets the pull_request_id" do
+          expect(ci_source.pull_request_id).to eq(pr_num)
         end
       end
     end

--- a/spec/lib/danger/ci_sources/gitlab_ci_spec.rb
+++ b/spec/lib/danger/ci_sources/gitlab_ci_spec.rb
@@ -2,95 +2,97 @@ require "danger/ci_source/gitlab_ci"
 
 RSpec.describe Danger::GitLabCI, host: :gitlab do
   context "valid environment" do
-    let(:env) { stub_env.merge("CI_MERGE_REQUEST_IID" => 28_493) }
-
+    let(:env) { stub_env }
     let(:ci_source) do
       described_class.new(env)
-    end
-
-    describe ".validates_as_ci?" do
-      it "is valid" do
-        expect(described_class.validates_as_ci?(env)).to be(true)
-      end
-    end
-
-    describe ".validates_as_pr?" do
-      it "is valid" do
-        expect(described_class.validates_as_pr?(env)).to be(true)
-      end
-    end
-
-    describe ".determine_pull_or_merge_request_id" do
-      context "when CI_MERGE_REQUEST_IID present in environment" do
-        it "returns CI_MERGE_REQUEST_IID" do
-          expect(described_class.determine_pull_or_merge_request_id({
-            "CI_MERGE_REQUEST_IID" => 1
-          })).to eq(1)
-        end
-      end
-
-      context "when CI_COMMIT_SHA not present in environment" do
-        it "returns 0" do
-          expect(
-            described_class.determine_pull_or_merge_request_id({})
-          ).to eq(0)
-        end
-      end
-
-      context "when CI_COMMIT_SHA present in environment" do
-        context "before version 10.7" do
-          it "uses gitlab api to find merge request id" do
-            stub_version("10.6.4")
-            stub_merge_requests("merge_requests_response", "k0nserv%2Fdanger-test")
-
-            expect(described_class.determine_pull_or_merge_request_id({
-              "CI_MERGE_REQUEST_PROJECT_PATH" => "k0nserv/danger-test",
-              "CI_COMMIT_SHA" => "3333333333333333333333333333333333333333",
-              "DANGER_GITLAB_API_TOKEN" => "a86e56d46ac78b"
-            })).to eq(3)
-          end
-        end
-        context "version 10.7 or later" do
-          it "uses gitlab api to find merge request id" do
-            #Arbitrary version, as tested manually, including text components to exercise the version comparison
-            stub_version("11.10.0-rc6-ee")
-            commit_sha = "3333333333333333333333333333333333333333"
-            stub_commit_merge_requests("commit_merge_requests", "k0nserv%2Fdanger-test", commit_sha)
-
-            expect(described_class.determine_pull_or_merge_request_id({
-              "CI_MERGE_REQUEST_PROJECT_PATH" => "k0nserv/danger-test",
-              "CI_COMMIT_SHA" => commit_sha,
-              "DANGER_GITLAB_API_TOKEN" => "a86e56d46ac78b"
-            })).to eq(1)
-          end
-        end
-      end
     end
 
     describe "#supported_request_sources" do
       it "it is gitlab" do
         expect(
           ci_source.supported_request_sources
-        ).to eq([Danger::RequestSources::GitHub,
-                 Danger::RequestSources::GitLab])
+        ).to eq([Danger::RequestSources::GitLab])
       end
     end
 
-    describe "#initialize" do
-      it "sets the repo_slug" do
-        expect(ci_source.repo_slug).to eq("k0nserv/danger-test")
-      end
-    end
+    context "given PR made on gitlab hosted repository" do
+      let(:env) { stub_env.merge("CI_MERGE_REQUEST_IID" => 28_493) }
 
-    describe "#project_url" do
-      it "sets the project_url" do
-        expect(ci_source.project_url).to eq(env["CI_MERGE_REQUEST_PROJECT_URL"])
+      describe ".validates_as_ci?" do
+        it "is valid" do
+          expect(described_class.validates_as_ci?(env)).to be(true)
+        end
       end
-    end
 
-    describe "#pull_request_id" do
-      it "sets the pull_request_id" do
-        expect(ci_source.pull_request_id).to eq(env["CI_MERGE_REQUEST_IID"])
+      describe ".validates_as_pr?" do
+        it "is valid" do
+          expect(described_class.validates_as_pr?(env)).to be(true)
+        end
+      end
+
+      describe ".determine_pull_or_merge_request_id" do
+        context "when CI_MERGE_REQUEST_IID present in environment" do
+          it "returns CI_MERGE_REQUEST_IID" do
+            expect(described_class.determine_pull_or_merge_request_id({
+              "CI_MERGE_REQUEST_IID" => 1
+            })).to eq(1)
+          end
+        end
+
+        context "when CI_COMMIT_SHA not present in environment" do
+          it "returns 0" do
+            expect(
+              described_class.determine_pull_or_merge_request_id({})
+            ).to eq(0)
+          end
+        end
+
+        context "when CI_COMMIT_SHA present in environment" do
+          context "before version 10.7" do
+            it "uses gitlab api to find merge request id" do
+              stub_version("10.6.4")
+              stub_merge_requests("merge_requests_response", "k0nserv%2Fdanger-test")
+
+              expect(described_class.determine_pull_or_merge_request_id({
+                "CI_MERGE_REQUEST_PROJECT_PATH" => "k0nserv/danger-test",
+                "CI_COMMIT_SHA" => "3333333333333333333333333333333333333333",
+                "DANGER_GITLAB_API_TOKEN" => "a86e56d46ac78b"
+              })).to eq(3)
+            end
+          end
+          context "version 10.7 or later" do
+            it "uses gitlab api to find merge request id" do
+              #Arbitrary version, as tested manually, including text components to exercise the version comparison
+              stub_version("11.10.0-rc6-ee")
+              commit_sha = "3333333333333333333333333333333333333333"
+              stub_commit_merge_requests("commit_merge_requests", "k0nserv%2Fdanger-test", commit_sha)
+
+              expect(described_class.determine_pull_or_merge_request_id({
+                "CI_MERGE_REQUEST_PROJECT_PATH" => "k0nserv/danger-test",
+                "CI_COMMIT_SHA" => commit_sha,
+                "DANGER_GITLAB_API_TOKEN" => "a86e56d46ac78b"
+              })).to eq(1)
+            end
+          end
+        end
+      end
+
+      describe "#initialize" do
+        it "sets the repo_slug" do
+          expect(ci_source.repo_slug).to eq("k0nserv/danger-test")
+        end
+      end
+
+      describe "#project_url" do
+        it "sets the project_url" do
+          expect(ci_source.project_url).to eq(env["CI_MERGE_REQUEST_PROJECT_URL"])
+        end
+      end
+
+      describe "#pull_request_id" do
+        it "sets the pull_request_id" do
+          expect(ci_source.pull_request_id).to eq(env["CI_MERGE_REQUEST_IID"])
+        end
       end
     end
   end

--- a/spec/lib/danger/ci_sources/gitlab_ci_spec.rb
+++ b/spec/lib/danger/ci_sources/gitlab_ci_spec.rb
@@ -20,10 +20,10 @@ RSpec.describe Danger::GitLabCI, host: :gitlab do
       end
     end
 
-    describe ".determine_merge_request_id" do
+    describe ".determine_pull_or_merge_request_id" do
       context "when CI_MERGE_REQUEST_IID present in environment" do
         it "returns CI_MERGE_REQUEST_IID" do
-          expect(described_class.determine_merge_request_id({
+          expect(described_class.determine_pull_or_merge_request_id({
             "CI_MERGE_REQUEST_IID" => 1
           })).to eq(1)
         end
@@ -31,7 +31,9 @@ RSpec.describe Danger::GitLabCI, host: :gitlab do
 
       context "when CI_COMMIT_SHA not present in environment" do
         it "returns 0" do
-          expect(described_class.determine_merge_request_id({})).to eq(0)
+          expect(
+            described_class.determine_pull_or_merge_request_id({})
+          ).to eq(0)
         end
       end
 
@@ -41,7 +43,7 @@ RSpec.describe Danger::GitLabCI, host: :gitlab do
             stub_version("10.6.4")
             stub_merge_requests("merge_requests_response", "k0nserv%2Fdanger-test")
 
-            expect(described_class.determine_merge_request_id({
+            expect(described_class.determine_pull_or_merge_request_id({
               "CI_MERGE_REQUEST_PROJECT_PATH" => "k0nserv/danger-test",
               "CI_COMMIT_SHA" => "3333333333333333333333333333333333333333",
               "DANGER_GITLAB_API_TOKEN" => "a86e56d46ac78b"
@@ -55,7 +57,7 @@ RSpec.describe Danger::GitLabCI, host: :gitlab do
             commit_sha = "3333333333333333333333333333333333333333"
             stub_commit_merge_requests("commit_merge_requests", "k0nserv%2Fdanger-test", commit_sha)
 
-            expect(described_class.determine_merge_request_id({
+            expect(described_class.determine_pull_or_merge_request_id({
               "CI_MERGE_REQUEST_PROJECT_PATH" => "k0nserv/danger-test",
               "CI_COMMIT_SHA" => commit_sha,
               "DANGER_GITLAB_API_TOKEN" => "a86e56d46ac78b"
@@ -67,7 +69,10 @@ RSpec.describe Danger::GitLabCI, host: :gitlab do
 
     describe "#supported_request_sources" do
       it "it is gitlab" do
-        expect(ci_source.supported_request_sources).to eq([Danger::RequestSources::GitLab])
+        expect(
+          ci_source.supported_request_sources
+        ).to eq([Danger::RequestSources::GitHub,
+                 Danger::RequestSources::GitLab])
       end
     end
 
@@ -89,7 +94,7 @@ RSpec.describe Danger::GitLabCI, host: :gitlab do
       end
     end
   end
-  
+
   context "valid environment on GitLab < 11.6" do
     let(:env) { stub_env_pre_11_6.merge("CI_MERGE_REQUEST_IID" => 28_493) }
 
@@ -102,12 +107,11 @@ RSpec.describe Danger::GitLabCI, host: :gitlab do
         expect(ci_source.repo_slug).to eq("k0nserv/danger-test")
       end
     end
-    
+
     describe "#project_url" do
       it "sets the project_url" do
         expect(ci_source.project_url).to eq(env["CI_PROJECT_URL"])
       end
     end
-
   end
 end

--- a/spec/lib/danger/request_sources/request_source_spec.rb
+++ b/spec/lib/danger/request_sources/request_source_spec.rb
@@ -21,15 +21,6 @@ RSpec.describe Danger::RequestSources::RequestSource, host: :github do
       allow(git_mock).to receive(:exec).with("remote show origin -n").and_return("Fetch URL: git@git.club-mateusa.com:artsy/eigen.git")
       expect(g.validates_as_ci?).to be true
     end
-
-    it 'doesn\'t validate when passed a wrong repository' do
-      git_mock = Danger::GitRepo.new
-      allow(git_mock).to receive(:exec).with("remote show origin -n").and_return("Fetch URL: git@bitbucket.org:artsy/eigen.git")
-
-      g = stub_request_source
-      g.scm = git_mock
-      expect(g.validates_as_ci?).to be false
-    end
   end
 
   describe ".source_name" do


### PR DESCRIPTION
It is common for code repos to be hosted on Github while using
Gitlab only as a CI/CD service.

Info on using Gitlab only as CI/CD service for external repos:
https://docs.gitlab.com/ee/ci/ci_cd_for_external_repos/

Current limitations:
- Unfortunately, Gitlab currently does not expose the external repo's
url, so users will have to manually set the repo's URL as an ENV var
`DANGER_PROJECT_REPO_URL` 
(for ex., `DANGER_PROJECT_REPO_URL=https://github.com/procore/blueprinter`).
- Additionally, `RequestSources::Github#validates_as_ci?` is tricky now because
the `git remote -v` returns `origin` as `gitlab.com` rather than `github.com`. The
reasoning is that even though the actual repo is on Github.com, GitlabCI maintains a
mirror on Gitlab.com and the CI checkout the code from the Gitlab.com mirror.